### PR TITLE
Update extension.js

### DIFF
--- a/undecorate@tabdeveloper.com/extension.js
+++ b/undecorate@tabdeveloper.com/extension.js
@@ -45,7 +45,7 @@ function enable() {
 
 // Return to the original class method.
 function disable() {
-    WindowMenu.prototype._buildMenu = buildMenu.old;
+    WindowMenu.prototype._buildMenu = old_buildMenu;
 
     global.display.disconnect(windowCreatedId);
 }


### PR DESCRIPTION
Receiving error in Gnome extension manager "buildMenu is not defined"
Line 48 changed from:
    WindowMenu.prototype._buildMenu = buildMenu.old;
to:
    WindowMenu.prototype._buildMenu = old_buildMenu;